### PR TITLE
fix: show Ronal's full portrait in hero

### DIFF
--- a/portfolio/build.sh
+++ b/portfolio/build.sh
@@ -21,6 +21,110 @@ if [ -s portrait/ronal-chhetri.png ]; then
   cp portrait/ronal-chhetri.png dist/legacy-theme/images/profile_pic.png
 fi
 
+# The original hero composition allocated only a shallow crop for the portrait.
+# Promote the image into the full arch card at runtime so Ronal's complete
+# upper-body portrait remains visible at desktop and mobile sizes.
+cat >> dist/assets/css/site.css <<'CSS'
+
+/* Full portrait composition */
+.ronal-full-portrait-host {
+  position: relative !important;
+  overflow: hidden !important;
+  isolation: isolate;
+}
+
+.ronal-full-portrait-host > .ronal-full-portrait {
+  position: absolute !important;
+  z-index: 1 !important;
+  left: 48% !important;
+  right: auto !important;
+  top: auto !important;
+  bottom: 0 !important;
+  display: block !important;
+  width: min(122%, 34rem) !important;
+  height: auto !important;
+  max-width: none !important;
+  max-height: 96% !important;
+  object-fit: contain !important;
+  object-position: center bottom !important;
+  transform: translateX(-50%) !important;
+  clip-path: none !important;
+  opacity: 1 !important;
+  filter: none !important;
+  pointer-events: none;
+}
+
+.ronal-full-portrait-host > :not(.ronal-full-portrait) {
+  z-index: 2;
+}
+
+@media (max-width: 48rem) {
+  .ronal-full-portrait-host > .ronal-full-portrait {
+    left: 50% !important;
+    width: min(116%, 29rem) !important;
+    max-height: 94% !important;
+  }
+}
+CSS
+
+cat >> dist/assets/js/site.js <<'JS'
+
+/* Move Ronal's portrait out of the old head-only crop and into the full hero arch. */
+(() => {
+  const placeFullPortrait = () => {
+    const portrait = Array.from(document.images).find((image) =>
+      /(?:^|\/)profile_pic\.png(?:\?|$)/.test(image.currentSrc || image.src)
+    );
+
+    if (!portrait || portrait.dataset.fullPortraitApplied === 'true') return;
+
+    const ancestors = [];
+    let node = portrait.parentElement;
+    while (node && node !== document.body) {
+      ancestors.push(node);
+      node = node.parentElement;
+    }
+
+    const host = ancestors.find((element) => {
+      const rect = element.getBoundingClientRect();
+      const style = getComputedStyle(element);
+      const radius = Math.max(
+        parseFloat(style.borderTopLeftRadius) || 0,
+        parseFloat(style.borderTopRightRadius) || 0
+      );
+      return rect.width >= 240 && rect.height >= 340 && rect.height > rect.width && radius >= 32;
+    }) || ancestors.find((element) => {
+      const rect = element.getBoundingClientRect();
+      return rect.width >= 240 && rect.height >= 340;
+    });
+
+    if (!host) return;
+
+    const previousParent = portrait.parentElement;
+    portrait.dataset.fullPortraitApplied = 'true';
+    portrait.classList.add('ronal-full-portrait');
+    host.classList.add('ronal-full-portrait-host');
+    host.prepend(portrait);
+
+    Array.from(host.children).forEach((child) => {
+      if (child === portrait) return;
+      if (getComputedStyle(child).position === 'static') child.style.position = 'relative';
+      child.style.zIndex = '2';
+    });
+
+    if (previousParent && previousParent !== host && previousParent.children.length === 0) {
+      previousParent.hidden = true;
+    }
+  };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', placeFullPortrait, { once: true });
+  } else {
+    placeFullPortrait();
+  }
+})();
+JS
+
 # Fail early when a core page or asset is missing.
 test -s dist/index.html
 test -s dist/resume.html


### PR DESCRIPTION
## What changed

- moves the supplied portrait out of the original shallow head-only crop
- anchors the complete upper-body image to the bottom of the hero arch
- preserves the existing card labels and overlays above the portrait
- adds responsive sizing for desktop and mobile
- keeps the supplied transparent portrait and legacy WordPress media unchanged

## Root cause

The image file already contained Ronal's full upper body. The hero layout constrained it inside a small portrait wrapper, so only his head was visible.

## Validation

- shell syntax check passed
- appended JavaScript syntax check passed
- portrait remains aspect-ratio safe with `object-fit: contain`
- Netlify deploy preview required before production merge
