### PR TITLE
fix: refresh portrait layout assets after deploy

### DIFF
--- a/portfolio/build.sh
+++ b/portfolio/build.sh
@@ -125,6 +125,18 @@ cat >> dist/assets/js/site.js <<'JS'
 })();
 JS
 
+# Version generated assets with the Netlify commit SHA so browsers cannot reuse
+# an older immutable CSS, JavaScript, or portrait response after deployment.
+asset_version="${COMMIT_REF:-local}"
+asset_version=$(printf '%s' "$asset_version" | cut -c1-12)
+for page in dist/*.html; do
+  sed -i \
+    -e "s|site\.css|site.css?v=$asset_version|g" \
+    -e "s|site\.js|site.js?v=$asset_version|g" \
+    -e "s|profile_pic\.png|profile_pic.png?v=$asset_version|g" \
+    "$page"
+done
+
 # Fail early when a core page or asset is missing.
 test -s dist/index.html
 test -s dist/resume.html


### PR DESCRIPTION
## What changed

- versions the generated CSS, JavaScript, and portrait URL with the Netlify commit SHA
- prevents browsers from reusing the earlier immutable head-only layout
- keeps long-term asset caching while making each deployment addressable by a unique URL

## Why

The full-portrait layout was deployed successfully, but the existing CSS and JavaScript URLs were previously served with a one-year immutable cache policy. Returning visitors could therefore keep seeing the old crop until manually clearing their browser cache.

## Validation

- shell syntax check passed
- JavaScript syntax check passed
- versioning runs against every generated HTML page
- Netlify deploy preview required before production merge
