### PR TITLE
fix: render Ronal portrait in hero card

### DIFF
--- a/portfolio/build.sh
+++ b/portfolio/build.sh
@@ -36,7 +36,7 @@ cat >> dist/assets/css/site.css <<'CSS'
 .ronal-portrait-card > .ronal-portrait-layer {
   position: absolute !important;
   inset: 0 !important;
-  z-index: 50 !important;
+  z-index: 2147483000 !important;
   display: flex !important;
   align-items: flex-end !important;
   justify-content: center !important;
@@ -67,7 +67,7 @@ cat >> dist/assets/css/site.css <<'CSS'
 
 .ronal-portrait-label {
   position: relative !important;
-  z-index: 60 !important;
+  z-index: 2147483001 !important;
 }
 
 @media (max-width: 48rem) {

--- a/portfolio/build.sh
+++ b/portfolio/build.sh
@@ -21,22 +21,22 @@ if [ -s portrait/ronal-chhetri.png ]; then
   cp portrait/ronal-chhetri.png dist/legacy-theme/images/profile_pic.png
 fi
 
-# Keep the original hero card and overlays intact. The source bundle crops the
-# portrait inside a shallow wrapper, so clone the same image into a full-card
-# presentation layer while leaving the original layout element in place.
+# Render the full supplied portrait as a stable layer inside the existing hero
+# card. The card is identified by its actual content rather than by dimensions,
+# border radii, or DOM relocation guesses.
 cat >> dist/assets/css/site.css <<'CSS'
 
-/* Full portrait inside the original hero card */
-.ronal-portrait-host {
+/* Ronal full portrait in the original hero card */
+.ronal-portrait-card {
   position: relative !important;
-  isolation: isolate;
+  isolation: isolate !important;
   overflow: hidden !important;
 }
 
-.ronal-portrait-layer {
+.ronal-portrait-card > .ronal-portrait-layer {
   position: absolute !important;
   inset: 0 !important;
-  z-index: 1 !important;
+  z-index: 50 !important;
   display: flex !important;
   align-items: flex-end !important;
   justify-content: center !important;
@@ -44,99 +44,114 @@ cat >> dist/assets/css/site.css <<'CSS'
   pointer-events: none !important;
 }
 
-.ronal-portrait-layer .ronal-full-portrait {
+.ronal-portrait-card > .ronal-portrait-layer > img {
   display: block !important;
-  flex: none !important;
-  width: min(118%, 34rem) !important;
-  height: auto !important;
+  width: 100% !important;
+  height: 100% !important;
   max-width: none !important;
-  max-height: 96% !important;
+  max-height: none !important;
   margin: 0 !important;
   object-fit: contain !important;
   object-position: center bottom !important;
-  transform: none !important;
-  clip-path: none !important;
   opacity: 1 !important;
   visibility: visible !important;
+  transform: none !important;
+  clip-path: none !important;
   filter: none !important;
 }
 
-.ronal-portrait-host > :not(.ronal-portrait-layer) {
-  position: relative;
-  z-index: 2;
+.ronal-original-portrait {
+  opacity: 0 !important;
+  visibility: hidden !important;
+}
+
+.ronal-portrait-label {
+  position: relative !important;
+  z-index: 60 !important;
 }
 
 @media (max-width: 48rem) {
-  .ronal-portrait-layer .ronal-full-portrait {
-    width: min(112%, 29rem) !important;
-    max-height: 94% !important;
+  .ronal-portrait-card > .ronal-portrait-layer > img {
+    width: 96% !important;
+    height: 96% !important;
   }
 }
 CSS
 
 cat >> dist/assets/js/site.js <<'JS'
 
-/* Preserve the old hero design while replacing its shallow head crop. */
+/* Attach Ronal's full portrait to the known hero card without moving its DOM. */
 (() => {
-  const installFullPortrait = () => {
+  const normalize = (value) => String(value || '').replace(/\s+/g, ' ').trim().toLowerCase();
+
+  const installPortrait = () => {
+    if (document.querySelector('.ronal-portrait-layer')) return;
+
     const source = Array.from(document.images).find((image) => {
-      const src = image.getAttribute('src') || image.currentSrc || image.src || '';
+      const src = image.currentSrc || image.getAttribute('src') || image.src || '';
       return /(?:^|\/)profile_pic\.png(?:\?|$)/.test(src);
     });
 
-    if (!source || source.dataset.fullPortraitSource === 'true') return;
+    if (!source) return;
 
-    const sourceFrame = source.parentElement;
-    if (!sourceFrame) return;
-
+    const requiredText = ['senior seo specialist', 'innovate nepal group'];
     const ancestors = [];
-    let node = sourceFrame.parentElement;
+    let node = source.parentElement;
+
     while (node && node !== document.body) {
       ancestors.push(node);
       node = node.parentElement;
     }
 
-    const host = ancestors.find((element) => {
+    const matchesCard = (element) => {
+      const text = normalize(element.textContent);
       const rect = element.getBoundingClientRect();
-      const style = getComputedStyle(element);
-      const radius = Math.max(
-        parseFloat(style.borderTopLeftRadius) || 0,
-        parseFloat(style.borderTopRightRadius) || 0
-      );
-      return rect.width >= 240 && rect.height >= 340 && rect.height > rect.width && radius >= 32;
-    }) || ancestors.find((element) => {
-      const rect = element.getBoundingClientRect();
-      return rect.width >= 240 && rect.height >= 340 && rect.height > rect.width;
-    });
+      return requiredText.every((needle) => text.includes(needle)) &&
+        rect.width >= 220 && rect.height >= 300;
+    };
 
-    if (!host) return;
+    let card = ancestors.find(matchesCard);
 
-    source.dataset.fullPortraitSource = 'true';
-    source.style.visibility = 'hidden';
+    if (!card) {
+      const candidates = Array.from(document.querySelectorAll('div, article, section, figure'))
+        .filter(matchesCard)
+        .sort((a, b) => {
+          const aRect = a.getBoundingClientRect();
+          const bRect = b.getBoundingClientRect();
+          return (aRect.width * aRect.height) - (bRect.width * bRect.height);
+        });
+      card = candidates[0];
+    }
+
+    if (!card) return;
 
     const layer = document.createElement('div');
     layer.className = 'ronal-portrait-layer';
     layer.setAttribute('aria-hidden', 'true');
 
-    const portrait = source.cloneNode(true);
-    portrait.removeAttribute('id');
-    portrait.removeAttribute('style');
-    portrait.removeAttribute('width');
-    portrait.removeAttribute('height');
-    portrait.removeAttribute('loading');
-    portrait.className = 'ronal-full-portrait';
+    const portrait = document.createElement('img');
+    portrait.src = source.currentSrc || source.src;
     portrait.alt = '';
-    portrait.dataset.fullPortraitClone = 'true';
+    portrait.decoding = 'async';
+    portrait.fetchPriority = 'high';
 
     layer.appendChild(portrait);
-    host.classList.add('ronal-portrait-host');
-    host.appendChild(layer);
+    card.classList.add('ronal-portrait-card');
+    card.appendChild(layer);
+    source.classList.add('ronal-original-portrait');
+
+    Array.from(card.querySelectorAll('*')).forEach((element) => {
+      const text = normalize(element.textContent);
+      if (requiredText.some((needle) => text === needle || text.includes(needle))) {
+        element.classList.add('ronal-portrait-label');
+      }
+    });
   };
 
   if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', installFullPortrait, { once: true });
+    document.addEventListener('DOMContentLoaded', installPortrait, { once: true });
   } else {
-    installFullPortrait();
+    installPortrait();
   }
 })();
 JS


### PR DESCRIPTION
## What changed

- removes the geometry-based portrait host detection that kept producing a blank hero card
- identifies the existing hero card by its stable content: “Senior SEO Specialist” and “Innovate Nepal Group”
- adds the supplied transparent portrait as a dedicated full-card layer
- keeps the original arch, card copy, labels, circles, and focus note intact
- uses `object-fit: contain` so Ronal’s complete upper body is visible without cropping
- retains commit-based cache versioning

## Root cause

The previous runtime code guessed the target container from its dimensions and border radius. It could select the wrong ancestor, leaving the visible hero card blank. This change binds the portrait to the actual content-bearing card and does not move any existing DOM nodes.

## Validation

- shell syntax check passed
- appended JavaScript syntax check passed with Node
- original portrait asset remains the user-supplied transparent PNG
- Netlify deploy preview required before production merge
