### PR TITLE
fix: embed hero portrait directly in markup

### DIFF
--- a/portfolio/build.sh
+++ b/portfolio/build.sh
@@ -22,105 +22,107 @@ if [ -s portrait/ronal-chhetri.png ]; then
 fi
 
 # Reconstruct the exact portrait supplied for the hero from text-safe chunks.
-# This avoids binary upload limitations while preserving the transparent image.
 if ls portrait/ronal-chhetri-hero.part-*.b64 >/dev/null 2>&1; then
   cat portrait/ronal-chhetri-hero.part-*.b64 \
     | base64 -d \
     > dist/legacy-theme/images/ronal-chhetri-hero.webp
 fi
 
+# Insert the portrait into the generated HTML itself. Runtime DOM guessing caused
+# the blank-card regressions, so the hero now owns a real image element.
+node <<'NODE'
+const fs = require('fs');
+const file = 'dist/index.html';
+let html = fs.readFileSync(file, 'utf8');
+
+if (!html.includes('ronal-hero-portrait')) {
+  const framePattern = /<([a-z][\w:-]*)\b([^>]*\bclass\s*=\s*(["'])([^"']*\bportrait-frame\b[^"']*)\3[^>]*)>/i;
+  const match = html.match(framePattern);
+
+  if (!match) {
+    throw new Error('Could not find the portrait-frame element in index.html');
+  }
+
+  const openingTag = match[0];
+  const quote = match[3];
+  const classes = match[4];
+  let upgradedTag = openingTag;
+
+  if (!/\bronal-portrait-card\b/.test(classes)) {
+    const escapedClasses = classes.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const classPattern = new RegExp(`class\\s*=\\s*${quote}${escapedClasses}${quote}`);
+    const updatedClasses = `${classes} ronal-portrait-card`.replace(/\s+/g, ' ').trim();
+    upgradedTag = openingTag.replace(classPattern, `class=${quote}${updatedClasses}${quote}`);
+  }
+
+  const portrait = '<img class="ronal-hero-portrait" src="/legacy-theme/images/ronal-chhetri-hero.webp?v=__RONAL_ASSET_VERSION__" alt="Ronal Chhetri" width="512" height="512" fetchpriority="high" decoding="async">';
+  html = html.replace(openingTag, `${upgradedTag}${portrait}`);
+  fs.writeFileSync(file, html);
+}
+NODE
+
 cat >> dist/assets/css/site.css <<'CSS'
 
-/* Exact uploaded portrait in the original hero card */
-.ronal-portrait-card {
+/* Exact uploaded portrait embedded directly in the original hero frame */
+.portrait-frame.ronal-portrait-card {
   position: relative !important;
   isolation: isolate !important;
   overflow: hidden !important;
 }
 
-.ronal-portrait-card::after {
-  content: "";
+.portrait-frame.ronal-portrait-card::before,
+.portrait-frame.ronal-portrait-card::after {
+  z-index: 1 !important;
+}
+
+.portrait-frame.ronal-portrait-card > .ronal-hero-portrait {
   position: absolute !important;
   inset: 0 !important;
-  z-index: 2147483000 !important;
+  z-index: 2 !important;
   display: block !important;
-  background-image: url('/legacy-theme/images/ronal-chhetri-hero.webp?v=__RONAL_ASSET_VERSION__') !important;
-  background-repeat: no-repeat !important;
-  background-position: center bottom !important;
-  background-size: contain !important;
+  width: 100% !important;
+  height: 100% !important;
+  max-width: none !important;
+  max-height: none !important;
+  margin: 0 !important;
+  object-fit: contain !important;
+  object-position: center bottom !important;
+  opacity: 1 !important;
+  visibility: visible !important;
+  transform: none !important;
+  clip-path: none !important;
+  filter: none !important;
   pointer-events: none !important;
 }
 
-.ronal-original-portrait {
+.portrait-frame.ronal-portrait-card img[src*="profile_pic.png"] {
   opacity: 0 !important;
   visibility: hidden !important;
 }
 
-.ronal-portrait-label {
-  position: relative !important;
-  z-index: 2147483001 !important;
+.portrait-frame.ronal-portrait-card > :not(.ronal-hero-portrait) {
+  z-index: 3 !important;
+}
+
+.portrait-frame.ronal-portrait-card :is(h1, h2, h3, h4, h5, h6, p, span, small, strong) {
+  position: relative;
+  z-index: 4 !important;
 }
 
 @media (max-width: 48rem) {
-  .ronal-portrait-card::after {
-    background-size: 96% auto !important;
+  .portrait-frame.ronal-portrait-card > .ronal-hero-portrait {
+    width: 96% !important;
+    height: 96% !important;
+    left: 2% !important;
+    top: 4% !important;
   }
 }
 CSS
 
-cat >> dist/assets/js/site.js <<'JS'
-
-/* Bind the exact uploaded portrait to the content-bearing hero card. */
-(() => {
-  const normalize = (value) => String(value || '').replace(/\s+/g, ' ').trim().toLowerCase();
-
-  const installPortrait = () => {
-    const requiredText = ['senior seo specialist', 'innovate nepal group'];
-    const candidates = Array.from(document.querySelectorAll('div, article, section, figure'))
-      .filter((element) => {
-        const text = normalize(element.textContent);
-        const rect = element.getBoundingClientRect();
-        return requiredText.every((needle) => text.includes(needle)) &&
-          rect.width >= 220 && rect.height >= 300;
-      })
-      .sort((a, b) => {
-        const aRect = a.getBoundingClientRect();
-        const bRect = b.getBoundingClientRect();
-        return (aRect.width * aRect.height) - (bRect.width * bRect.height);
-      });
-
-    const card = candidates[0];
-    if (!card) return;
-
-    card.classList.add('ronal-portrait-card');
-
-    Array.from(card.querySelectorAll('img')).forEach((image) => {
-      const src = image.currentSrc || image.getAttribute('src') || image.src || '';
-      if (/(?:^|\/)profile_pic\.png(?:\?|$)/.test(src)) {
-        image.classList.add('ronal-original-portrait');
-      }
-    });
-
-    Array.from(card.querySelectorAll('*')).forEach((element) => {
-      const text = normalize(element.textContent);
-      if (requiredText.some((needle) => text === needle || text.includes(needle))) {
-        element.classList.add('ronal-portrait-label');
-      }
-    });
-  };
-
-  if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', installPortrait, { once: true });
-  } else {
-    installPortrait();
-  }
-})();
-JS
-
 # Version generated assets so browsers cannot reuse a previous hero layout.
 asset_version="${COMMIT_REF:-local}"
 asset_version=$(printf '%s' "$asset_version" | cut -c1-12)
-sed -i "s|__RONAL_ASSET_VERSION__|$asset_version|g" dist/assets/css/site.css
+sed -i "s|__RONAL_ASSET_VERSION__|$asset_version|g" dist/index.html
 
 for page in dist/*.html; do
   sed -i \
@@ -135,5 +137,7 @@ test -s dist/resume.html
 test -s dist/assets/css/site.css
 test -s dist/assets/js/site.js
 test -s dist/legacy-theme/images/ronal-chhetri-hero.webp
+grep -q 'class="ronal-hero-portrait"' dist/index.html
+grep -q 'portrait-frame ronal-portrait-card' dist/index.html
 
 printf '%s\n' 'Ronal Chhetri portfolio built in portfolio/dist/'


### PR DESCRIPTION
## What changed

- inserts the uploaded Ronal portrait as a real `<img>` directly inside `.portrait-frame.ronal-portrait-card`
- removes the runtime DOM-search and pseudo-element portrait approach
- hides only the obsolete cropped `profile_pic.png` inside the hero frame
- keeps the original arch, labels, focus card, and responsive layout
- uses `object-fit: contain` and bottom alignment so the full upper body remains visible
- adds build assertions that fail when the direct portrait markup or card class is missing
- preserves commit-based asset versioning

## Root cause

The previous implementation added the portrait through JavaScript and a generated pseudo-element. The card could render before the correct class was attached, leaving the visible frame blank. This change makes the image part of the generated HTML, so it renders without runtime discovery.

## Validation

- shell syntax check passed
- build-time HTML injection tested against representative portrait-frame markup
- generated markup includes both `portrait-frame ronal-portrait-card` and `ronal-hero-portrait`
- Netlify deploy preview required before production merge
