### PR TITLE
feat: launch-ready mobile navigation and SEO

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,11 +5,24 @@
 
 [build.environment]
   NODE_VERSION = "22"
+  NODE_ENV = "production"
+
+[[redirects]]
+  from = "/resume.html"
+  to = "/resume"
+  status = 301
+  force = true
 
 [[redirects]]
   from = "/resume"
   to = "/resume.html"
   status = 200
+
+[[redirects]]
+  from = "/legacy.html"
+  to = "/legacy"
+  status = 301
+  force = true
 
 [[redirects]]
   from = "/legacy"
@@ -30,6 +43,7 @@
     Referrer-Policy = "strict-origin-when-cross-origin"
     Permissions-Policy = "camera=(), microphone=(), geolocation=(), payment=()"
     Cross-Origin-Opener-Policy = "same-origin"
+    X-Permitted-Cross-Domain-Policies = "none"
 
 [[headers]]
   for = "/*.html"
@@ -42,6 +56,31 @@
     Cache-Control = "public, max-age=31536000, immutable"
 
 [[headers]]
+  for = "/robots.txt"
+  [headers.values]
+    Cache-Control = "public, max-age=3600, must-revalidate"
+
+[[headers]]
+  for = "/sitemap.xml"
+  [headers.values]
+    Cache-Control = "public, max-age=3600, must-revalidate"
+
+[[headers]]
+  for = "/legacy"
+  [headers.values]
+    X-Robots-Tag = "noindex, follow"
+
+[[headers]]
   for = "/legacy.html"
   [headers.values]
     X-Robots-Tag = "noindex, follow"
+
+[[headers]]
+  for = "/thanks.html"
+  [headers.values]
+    X-Robots-Tag = "noindex, nofollow"
+
+[[headers]]
+  for = "/404.html"
+  [headers.values]
+    X-Robots-Tag = "noindex, nofollow"

--- a/portfolio/build.sh
+++ b/portfolio/build.sh
@@ -40,9 +40,7 @@ if (!html.includes('ronal-hero-portrait')) {
   const framePattern = /<([a-z][\w:-]*)\b([^>]*\bclass\s*=\s*(["'])([^"']*\bportrait-frame\b[^"']*)\3[^>]*)>/i;
   const match = html.match(framePattern);
 
-  if (!match) {
-    throw new Error('Could not find the portrait-frame element in index.html');
-  }
+  if (!match) throw new Error('Could not find the portrait-frame element in index.html');
 
   const openingTag = match[0];
   const quote = match[3];
@@ -56,11 +54,14 @@ if (!html.includes('ronal-hero-portrait')) {
     upgradedTag = openingTag.replace(classPattern, `class=${quote}${updatedClasses}${quote}`);
   }
 
-  const portrait = `<img class="ronal-hero-portrait" src="https://i.imgur.com/5N1j1Ie.png" alt="Ronal Chhetri" width="1024" height="1024" loading="eager" fetchpriority="high" decoding="async" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='/legacy-theme/images/ronal-chhetri-hero.webp?v=__RONAL_ASSET_VERSION__'">`;
+  const portrait = `<img class="ronal-hero-portrait" src="https://i.imgur.com/5N1j1Ie.png" alt="Ronal Chhetri, Senior SEO Specialist and Analyst" width="1024" height="1024" loading="eager" fetchpriority="high" decoding="async" referrerpolicy="no-referrer" onerror="this.onerror=null;this.src='/legacy-theme/images/ronal-chhetri-hero.webp?v=__RONAL_ASSET_VERSION__'">`;
   html = html.replace(openingTag, `${upgradedTag}${portrait}`);
   fs.writeFileSync(file, html);
 }
 NODE
+
+# Apply launch-ready navigation, on-page content, metadata, schema and crawl files.
+node launch-enhancements.js
 
 cat >> dist/assets/css/site.css <<'CSS'
 
@@ -72,9 +73,7 @@ cat >> dist/assets/css/site.css <<'CSS'
 }
 
 .portrait-frame.ronal-portrait-card::before,
-.portrait-frame.ronal-portrait-card::after {
-  z-index: 1 !important;
-}
+.portrait-frame.ronal-portrait-card::after { z-index: 1 !important; }
 
 .portrait-frame.ronal-portrait-card > .ronal-hero-portrait {
   position: absolute !important;
@@ -101,11 +100,8 @@ cat >> dist/assets/css/site.css <<'CSS'
   visibility: hidden !important;
 }
 
-.portrait-frame.ronal-portrait-card > :not(.ronal-hero-portrait) {
-  z-index: 3 !important;
-}
-
-.portrait-frame.ronal-portrait-card :is(h1, h2, h3, h4, h5, h6, p, span, small, strong) {
+.portrait-frame.ronal-portrait-card > :not(.ronal-hero-portrait) { z-index: 3 !important; }
+.portrait-frame.ronal-portrait-card :is(h1,h2,h3,h4,h5,h6,p,span,small,strong) {
   position: relative;
   z-index: 4 !important;
 }
@@ -120,7 +116,10 @@ cat >> dist/assets/css/site.css <<'CSS'
 }
 CSS
 
-# Version generated assets so browsers cannot reuse a previous hero layout.
+cat launch-enhancements.css >> dist/assets/css/site.css
+cat launch-navigation.js >> dist/assets/js/site.js
+
+# Version generated assets so browsers cannot reuse a previous layout or script.
 asset_version="${COMMIT_REF:-local}"
 asset_version=$(printf '%s' "$asset_version" | cut -c1-12)
 sed -i "s|__RONAL_ASSET_VERSION__|$asset_version|g" dist/index.html
@@ -132,14 +131,15 @@ for page in dist/*.html; do
     "$page"
 done
 
-# Fail early when a core page, asset, or requested hero URL is missing.
+# Fail early when a core page, asset, menu, or SEO requirement is missing.
 test -s dist/index.html
 test -s dist/resume.html
 test -s dist/assets/css/site.css
 test -s dist/assets/js/site.js
 test -s dist/legacy-theme/images/ronal-chhetri-hero.webp
-grep -q 'class="ronal-hero-portrait"' dist/index.html
-grep -q 'portrait-frame ronal-portrait-card' dist/index.html
-grep -q 'src="https://i.imgur.com/5N1j1Ie.png"' dist/index.html
+test -s dist/robots.txt
+test -s dist/sitemap.xml
+node --check dist/assets/js/site.js
+node launch-verify.js
 
-printf '%s\n' 'Ronal Chhetri portfolio built in portfolio/dist/'
+printf '%s\n' 'Ronal Chhetri launch build passed mobile navigation and SEO validation.'

--- a/portfolio/launch-enhancements.css
+++ b/portfolio/launch-enhancements.css
@@ -1,0 +1,112 @@
+
+/* Launch-ready mobile navigation */
+.launch-mobile-toggle,
+.launch-mobile-drawer,
+.launch-nav-backdrop { display: none; }
+.launch-original-menu-toggle { display: none !important; }
+
+@media (max-width: 56.25rem) {
+  .launch-desktop-nav { display: none !important; }
+  .launch-mobile-toggle {
+    position: relative; z-index: 2147483003; display: inline-grid !important;
+    width: 2.875rem; height: 2.875rem; margin-left: auto; padding: 0.7rem;
+    place-content: center; gap: 0.28rem; border: 1px solid rgba(127,127,127,.42);
+    border-radius: 999px; background: rgba(18,22,18,.84); color: #f7f7f1;
+    cursor: pointer; -webkit-tap-highlight-color: transparent;
+  }
+  .launch-mobile-toggle span {
+    display: block; width: 1.25rem; height: 2px; border-radius: 2px;
+    background: currentColor; transform-origin: center;
+    transition: transform 180ms ease, opacity 180ms ease;
+  }
+  .launch-mobile-toggle[aria-expanded="true"] { position: fixed; top: 1rem; right: 1rem; }
+  .launch-mobile-toggle[aria-expanded="true"] span:nth-child(1) { transform: translateY(.38rem) rotate(45deg); }
+  .launch-mobile-toggle[aria-expanded="true"] span:nth-child(2) { opacity: 0; }
+  .launch-mobile-toggle[aria-expanded="true"] span:nth-child(3) { transform: translateY(-.38rem) rotate(-45deg); }
+  .launch-mobile-drawer {
+    position: fixed !important; z-index: 2147483002 !important; inset: 0 0 0 auto !important;
+    display: flex !important; width: min(88vw,24rem) !important; height: 100dvh !important;
+    padding: 6rem 1.5rem 2rem !important; flex-direction: column !important;
+    align-items: stretch !important; justify-content: flex-start !important; gap: .35rem !important;
+    overflow-y: auto !important; border-left: 1px solid rgba(255,255,255,.14) !important;
+    background: #0d120e !important; box-shadow: -1.5rem 0 4rem rgba(0,0,0,.4) !important;
+    opacity: 0 !important; visibility: hidden !important; pointer-events: none !important;
+    transform: translateX(105%) !important;
+    transition: transform 220ms ease, opacity 180ms ease, visibility 220ms step-end !important;
+  }
+  .launch-mobile-drawer.is-open {
+    opacity: 1 !important; visibility: visible !important; pointer-events: auto !important;
+    transform: translateX(0) !important;
+    transition: transform 220ms ease, opacity 180ms ease, visibility 0s step-start !important;
+  }
+  .launch-mobile-drawer .launch-mobile-link {
+    display: flex !important; min-height: 3.25rem !important; padding: .8rem .25rem !important;
+    align-items: center !important; border-bottom: 1px solid rgba(255,255,255,.12) !important;
+    color: #f7f7f1 !important; font-size: clamp(1.18rem,5vw,1.7rem) !important;
+    font-weight: 650 !important; line-height: 1.15 !important; text-decoration: none !important;
+  }
+  .launch-mobile-drawer .launch-mobile-link:hover,
+  .launch-mobile-drawer .launch-mobile-link:focus-visible { color: #c8ff2e !important; }
+  .launch-nav-backdrop {
+    position: fixed; z-index: 2147483001; inset: 0; display: block;
+    background: rgba(0,0,0,.58); opacity: 0; visibility: hidden; pointer-events: none;
+    transition: opacity 180ms ease, visibility 180ms step-end;
+  }
+  .launch-nav-backdrop.is-open {
+    opacity: 1; visibility: visible; pointer-events: auto;
+    transition: opacity 180ms ease, visibility 0s step-start;
+  }
+  body.launch-nav-open { overflow: hidden !important; touch-action: none; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .launch-mobile-toggle span, .launch-mobile-drawer, .launch-nav-backdrop { transition: none !important; }
+}
+
+/* Search-focused services section */
+.launch-services {
+  padding: clamp(4.75rem,9vw,8rem) 0;
+  border-top: 1px solid rgba(127,127,127,.24);
+  border-bottom: 1px solid rgba(127,127,127,.24);
+}
+.launch-services__inner { width: min(100% - 2rem,75rem); margin-inline: auto; }
+.launch-services__eyebrow {
+  margin: 0 0 1.25rem; color: #89ad19; font-size: .76rem; font-weight: 800; letter-spacing: .16em;
+}
+.launch-services__intro {
+  display: grid; grid-template-columns: minmax(0,1.2fr) minmax(16rem,.8fr);
+  gap: clamp(1.5rem,5vw,5rem); align-items: end; margin-bottom: clamp(2.5rem,6vw,4.5rem);
+}
+.launch-services__intro h2 {
+  max-width: 13ch; margin: 0; font-size: clamp(2.4rem,6vw,5.4rem);
+  line-height: .98; letter-spacing: -.055em;
+}
+.launch-services__intro p {
+  max-width: 42rem; margin: 0; font-size: clamp(1rem,1.8vw,1.2rem); line-height: 1.7; opacity: .78;
+}
+.launch-services__grid { display: grid; grid-template-columns: repeat(3,minmax(0,1fr)); gap: 1rem; }
+.launch-services__card {
+  min-height: 19rem; padding: clamp(1.4rem,3vw,2rem);
+  border: 1px solid rgba(127,127,127,.28); border-radius: 1.25rem;
+  background: rgba(127,127,127,.065);
+}
+.launch-services__card > span {
+  display: inline-flex; margin-bottom: clamp(3rem,7vw,5.5rem);
+  color: #89ad19; font-size: .78rem; font-weight: 850; letter-spacing: .14em;
+}
+.launch-services__card h3 { margin: 0 0 1rem; font-size: clamp(1.25rem,2.2vw,1.7rem); line-height: 1.12; }
+.launch-services__card p { margin: 0; line-height: 1.65; opacity: .72; }
+.launch-services__actions { display: flex; flex-wrap: wrap; gap: .75rem; margin-top: 2rem; }
+.launch-services__actions a {
+  display: inline-flex; min-height: 2.85rem; padding: .8rem 1.2rem;
+  align-items: center; justify-content: center; border-radius: 999px;
+  font-weight: 750; text-decoration: none;
+}
+.launch-services__primary { background: #c8ff2e; color: #11150f !important; }
+.launch-services__secondary { border: 1px solid rgba(127,127,127,.42); color: inherit !important; }
+
+@media (max-width: 48rem) {
+  .launch-services__intro, .launch-services__grid { grid-template-columns: 1fr; }
+  .launch-services__card { min-height: 0; }
+  .launch-services__card > span { margin-bottom: 2.5rem; }
+}

--- a/portfolio/launch-enhancements.js
+++ b/portfolio/launch-enhancements.js
@@ -1,0 +1,297 @@
+'use strict';
+
+const fs = require('fs');
+
+const SITE = 'https://ronalchettri.netlify.app';
+const PORTRAIT = 'https://i.imgur.com/5N1j1Ie.png';
+const LINKEDIN = 'https://www.linkedin.com/in/ronal-chhetri/';
+const MODIFIED = '2026-08-06';
+
+function escapeRegex(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function escapeAttr(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+function insertIntoHead(doc, markup) {
+  if (!/<\/head>/i.test(doc)) throw new Error('Missing closing head element');
+  return doc.replace(/<\/head>/i, `  ${markup}\n</head>`);
+}
+
+function setTitle(doc, title) {
+  const tag = `<title>${title}</title>`;
+  return /<title\b[^>]*>[\s\S]*?<\/title>/i.test(doc)
+    ? doc.replace(/<title\b[^>]*>[\s\S]*?<\/title>/i, tag)
+    : insertIntoHead(doc, tag);
+}
+
+function setMeta(doc, attribute, key, content) {
+  const pattern = new RegExp(`<meta\\b(?=[^>]*\\b${attribute}\\s*=\\s*["']${escapeRegex(key)}["'])[^>]*>`, 'i');
+  const tag = `<meta ${attribute}="${escapeAttr(key)}" content="${escapeAttr(content)}">`;
+  return pattern.test(doc) ? doc.replace(pattern, tag) : insertIntoHead(doc, tag);
+}
+
+function removeMeta(doc, name) {
+  const pattern = new RegExp(`\\s*<meta\\b(?=[^>]*\\bname\\s*=\\s*["']${escapeRegex(name)}["'])[^>]*>`, 'ig');
+  return doc.replace(pattern, '');
+}
+
+function setCanonical(doc, href) {
+  const pattern = /<link\b(?=[^>]*\brel\s*=\s*["']canonical["'])[^>]*>/i;
+  const tag = `<link rel="canonical" href="${escapeAttr(href)}">`;
+  return pattern.test(doc) ? doc.replace(pattern, tag) : insertIntoHead(doc, tag);
+}
+
+function addHeadMarkup(doc, marker, markup) {
+  return doc.includes(marker) ? doc : insertIntoHead(doc, markup);
+}
+
+function setHtmlLang(doc, language) {
+  if (!/<html\b/i.test(doc)) throw new Error('Missing html element');
+  return /<html\b[^>]*\blang\s*=/i.test(doc)
+    ? doc.replace(/(<html\b[^>]*\blang\s*=\s*)["'][^"']*["']/i, `$1"${language}"`)
+    : doc.replace(/<html\b/i, `<html lang="${language}"`);
+}
+
+function addClass(openingTag, className) {
+  const match = openingTag.match(/\bclass\s*=\s*(["'])([^"']*)\1/i);
+  if (!match) return openingTag.replace(/>$/, ` class="${className}">`);
+  const classes = new Set(match[2].split(/\s+/).filter(Boolean));
+  classes.add(className);
+  return openingTag.replace(match[0], `class=${match[1]}${Array.from(classes).join(' ')}${match[1]}`);
+}
+
+function setAttribute(openingTag, name, value) {
+  const pattern = new RegExp(`\\s${escapeRegex(name)}\\s*=\\s*(["'])[^"']*\\1`, 'i');
+  return pattern.test(openingTag)
+    ? openingTag.replace(pattern, ` ${name}="${escapeAttr(value)}"`)
+    : openingTag.replace(/>$/, ` ${name}="${escapeAttr(value)}">`);
+}
+
+function installNavigation(doc) {
+  if (doc.includes('id="launch-mobile-drawer"')) return doc;
+
+  const matches = Array.from(doc.matchAll(/<nav\b[^>]*>[\s\S]*?<\/nav>/gi));
+  if (!matches.length) throw new Error('Could not find a navigation element in index.html');
+
+  const scored = matches.map((match) => {
+    const block = match[0];
+    const lower = block.toLowerCase();
+    const anchorCount = (block.match(/<a\b/gi) || []).length;
+    let score = anchorCount;
+    ['#work', '#expertise', '#experience', '#contact'].forEach((needle) => {
+      if (lower.includes(needle)) score += 10;
+    });
+    return { match, block, score };
+  }).sort((a, b) => b.score - a.score);
+
+  const selected = scored[0];
+  if (selected.score < 4) throw new Error('Could not identify the primary navigation');
+
+  let desktopNav = selected.block;
+  const opening = desktopNav.match(/^<nav\b[^>]*>/i)[0];
+  let upgradedOpening = addClass(opening, 'launch-desktop-nav');
+  upgradedOpening = setAttribute(upgradedOpening, 'aria-label', 'Primary navigation');
+  desktopNav = desktopNav.replace(opening, upgradedOpening);
+
+  if (!/href\s*=\s*["'][^"']*#services/i.test(desktopNav)) {
+    const servicesLink = '<a href="#services">Services</a>';
+    const contactPattern = /<a\b[^>]*href\s*=\s*(["'])[^"']*#contact[^"']*\1[^>]*>/i;
+    desktopNav = contactPattern.test(desktopNav)
+      ? desktopNav.replace(contactPattern, `${servicesLink}$&`)
+      : desktopNav.replace(/<\/nav>/i, `${servicesLink}</nav>`);
+  }
+
+  const anchors = desktopNav.match(/<a\b[^>]*>[\s\S]*?<\/a>/gi) || [];
+  if (anchors.length < 4) throw new Error('Primary navigation has too few links');
+
+  const mobileLinks = anchors.map((anchor) => {
+    let clean = anchor.replace(/\s+id\s*=\s*(["'])[^"']*\1/ig, '');
+    const tag = clean.match(/^<a\b[^>]*>/i)[0];
+    clean = clean.replace(tag, addClass(tag, 'launch-mobile-link'));
+    return clean;
+  }).join('\n');
+
+  const button = '<button class="launch-mobile-toggle" type="button" aria-controls="launch-mobile-drawer" aria-expanded="false" aria-label="Open navigation menu"><span></span><span></span><span></span></button>';
+  const drawer = `<nav id="launch-mobile-drawer" class="launch-mobile-drawer" aria-label="Mobile navigation" aria-hidden="true" tabindex="-1">${mobileLinks}</nav>`;
+  const backdrop = '<div class="launch-nav-backdrop" aria-hidden="true"></div>';
+  const replacement = `${button}${desktopNav}${drawer}${backdrop}`;
+
+  return doc.slice(0, selected.match.index) + replacement + doc.slice(selected.match.index + selected.block.length);
+}
+
+function installServices(doc) {
+  if (/\bid\s*=\s*["']services["']/i.test(doc)) return doc;
+
+  const section = `
+<section id="services" class="launch-services" aria-labelledby="launch-services-title">
+  <div class="launch-services__inner">
+    <p class="launch-services__eyebrow">SEO SERVICES</p>
+    <div class="launch-services__intro">
+      <h2 id="launch-services-title">SEO strategy that teams can actually ship.</h2>
+      <p>As a Nepal-based Senior SEO Specialist and Analyst, Ronal turns technical findings, search intent and performance data into clear priorities that developers, writers and stakeholders can implement.</p>
+    </div>
+    <div class="launch-services__grid">
+      <article class="launch-services__card">
+        <span>01</span>
+        <h3>Technical SEO and site architecture</h3>
+        <p>Crawlability, indexation, internal linking, structured data and site architecture are reviewed as one connected search system rather than a pile of isolated warnings.</p>
+      </article>
+      <article class="launch-services__card">
+        <span>02</span>
+        <h3>Keyword and content strategy</h3>
+        <p>Keyword research, intent mapping and content planning connect audience demand with useful pages, stronger information architecture and realistic publishing priorities.</p>
+      </article>
+      <article class="launch-services__card">
+        <span>03</span>
+        <h3>Measurement and implementation</h3>
+        <p>Search reporting translates visibility, engagement and conversion signals into decisions, implementation briefs and a practical roadmap for continuous improvement.</p>
+      </article>
+    </div>
+    <div class="launch-services__actions">
+      <a class="launch-services__primary" href="#contact">Discuss an SEO project</a>
+      <a class="launch-services__secondary" href="/resume">Review experience</a>
+    </div>
+  </div>
+</section>`;
+
+  const contact = doc.match(/<section\b[^>]*\bid\s*=\s*["']contact["'][^>]*>/i);
+  if (contact) return doc.replace(contact[0], `${section}\n${contact[0]}`);
+  if (/<\/main>/i.test(doc)) return doc.replace(/<\/main>/i, `${section}\n</main>`);
+  return doc.replace(/<\/body>/i, `${section}\n</body>`);
+}
+
+function applyPageMetadata(doc, config) {
+  doc = setHtmlLang(doc, 'en');
+  doc = removeMeta(doc, 'keywords');
+  doc = setTitle(doc, config.title);
+  doc = setMeta(doc, 'name', 'description', config.description);
+  doc = setMeta(doc, 'name', 'robots', config.robots);
+  doc = setMeta(doc, 'name', 'author', 'Ronal Chhetri');
+  doc = setMeta(doc, 'name', 'theme-color', '#0d120e');
+  doc = setCanonical(doc, config.canonical);
+  doc = setMeta(doc, 'property', 'og:locale', 'en_NP');
+  doc = setMeta(doc, 'property', 'og:type', config.ogType || 'profile');
+  doc = setMeta(doc, 'property', 'og:title', config.title);
+  doc = setMeta(doc, 'property', 'og:description', config.description);
+  doc = setMeta(doc, 'property', 'og:url', config.canonical);
+  doc = setMeta(doc, 'property', 'og:site_name', 'Ronal Chhetri');
+  doc = setMeta(doc, 'property', 'og:image', PORTRAIT);
+  doc = setMeta(doc, 'property', 'og:image:width', '1024');
+  doc = setMeta(doc, 'property', 'og:image:height', '1024');
+  doc = setMeta(doc, 'property', 'og:image:alt', 'Portrait of Ronal Chhetri');
+  doc = setMeta(doc, 'name', 'twitter:card', 'summary_large_image');
+  doc = setMeta(doc, 'name', 'twitter:title', config.title);
+  doc = setMeta(doc, 'name', 'twitter:description', config.description);
+  doc = setMeta(doc, 'name', 'twitter:image', PORTRAIT);
+  doc = setMeta(doc, 'name', 'twitter:image:alt', 'Portrait of Ronal Chhetri');
+  doc = addHeadMarkup(doc, 'href="https://i.imgur.com"', '<link rel="preconnect" href="https://i.imgur.com" crossorigin>');
+  doc = addHeadMarkup(doc, 'rel="me"', `<link rel="me" href="${LINKEDIN}">`);
+  return doc;
+}
+
+let index = fs.readFileSync('dist/index.html', 'utf8');
+index = installNavigation(index);
+index = installServices(index);
+index = applyPageMetadata(index, {
+  title: 'Ronal Chhetri | Senior SEO Specialist and Technical SEO Analyst',
+  description: 'Ronal Chhetri is a Nepal-based Senior SEO Specialist helping brands improve technical SEO, content strategy, keyword visibility, structured data and reporting.',
+  canonical: `${SITE}/`,
+  robots: 'index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1',
+  ogType: 'profile'
+});
+
+index = index.replace(/\s*<script\b[^>]*type\s*=\s*["']application\/ld\+json["'][^>]*>[\s\S]*?<\/script>/ig, '');
+const structuredData = {
+  '@context': 'https://schema.org',
+  '@graph': [
+    {
+      '@type': 'WebSite',
+      '@id': `${SITE}/#website`,
+      url: `${SITE}/`,
+      name: 'Ronal Chhetri - Senior SEO Specialist',
+      inLanguage: 'en',
+      publisher: { '@id': `${SITE}/#person` }
+    },
+    {
+      '@type': 'ProfilePage',
+      '@id': `${SITE}/#profilepage`,
+      url: `${SITE}/`,
+      name: 'Ronal Chhetri - Senior SEO Specialist and Analyst',
+      isPartOf: { '@id': `${SITE}/#website` },
+      mainEntity: { '@id': `${SITE}/#person` },
+      dateModified: MODIFIED,
+      inLanguage: 'en'
+    },
+    {
+      '@type': 'Person',
+      '@id': `${SITE}/#person`,
+      name: 'Ronal Chhetri',
+      url: `${SITE}/`,
+      image: { '@type': 'ImageObject', url: PORTRAIT, width: 1024, height: 1024 },
+      jobTitle: 'Senior SEO Specialist and Analyst',
+      worksFor: { '@type': 'Organization', name: 'Innovate Nepal Group' },
+      sameAs: [LINKEDIN],
+      knowsAbout: [
+        'Technical SEO',
+        'SEO strategy',
+        'Keyword research',
+        'Content strategy',
+        'Structured data',
+        'Search analytics',
+        'Search performance reporting'
+      ],
+      address: { '@type': 'PostalAddress', addressCountry: 'NP' }
+    }
+  ]
+};
+index = insertIntoHead(index, `<script type="application/ld+json">${JSON.stringify(structuredData)}</script>`);
+fs.writeFileSync('dist/index.html', index);
+
+if (fs.existsSync('dist/resume.html')) {
+  let resume = fs.readFileSync('dist/resume.html', 'utf8');
+  resume = applyPageMetadata(resume, {
+    title: 'Ronal Chhetri Resume | Senior SEO Specialist and Analyst',
+    description: 'Review Ronal Chhetri\'s SEO experience, technical expertise, content strategy background, professional credentials and career history.',
+    canonical: `${SITE}/resume`,
+    robots: 'index,follow,max-image-preview:large',
+    ogType: 'profile'
+  });
+  fs.writeFileSync('dist/resume.html', resume);
+}
+
+for (const [file, directive] of [
+  ['dist/legacy.html', 'noindex,follow'],
+  ['dist/thanks.html', 'noindex,nofollow'],
+  ['dist/404.html', 'noindex,nofollow']
+]) {
+  if (!fs.existsSync(file)) continue;
+  let page = fs.readFileSync(file, 'utf8');
+  page = setHtmlLang(page, 'en');
+  page = setMeta(page, 'name', 'robots', directive);
+  fs.writeFileSync(file, page);
+}
+
+fs.writeFileSync('dist/robots.txt', `User-agent: *\nAllow: /\n\nSitemap: ${SITE}/sitemap.xml\n`);
+fs.writeFileSync('dist/sitemap.xml', `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>${SITE}/</loc>
+    <lastmod>${MODIFIED}</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>${SITE}/resume</loc>
+    <lastmod>${MODIFIED}</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+</urlset>
+`);

--- a/portfolio/launch-navigation.js
+++ b/portfolio/launch-navigation.js
@@ -1,0 +1,105 @@
+
+/* Deterministic, accessible mobile navigation. */
+(() => {
+  const initializeLaunchNavigation = () => {
+    const toggle = document.querySelector('.launch-mobile-toggle');
+    const drawer = document.getElementById('launch-mobile-drawer');
+    const backdrop = document.querySelector('.launch-nav-backdrop');
+    if (!toggle || !drawer || !backdrop || toggle.dataset.launchReady === 'true') return;
+
+    toggle.dataset.launchReady = 'true';
+    const mobileQuery = window.matchMedia('(max-width: 56.25rem)');
+    let lastFocused = null;
+
+    document.querySelectorAll('header button').forEach((candidate) => {
+      if (candidate === toggle) return;
+      const fingerprint = [candidate.getAttribute('aria-label'), candidate.getAttribute('title'), candidate.className, candidate.textContent]
+        .filter(Boolean).join(' ').toLowerCase();
+      if (/(menu|navigation|hamburger|nav-toggle)/.test(fingerprint) && !/(theme|dark|light|mode|color)/.test(fingerprint)) {
+        candidate.classList.add('launch-original-menu-toggle');
+        candidate.setAttribute('aria-hidden', 'true');
+        candidate.tabIndex = -1;
+      }
+    });
+
+    const focusableItems = () => Array.from(drawer.querySelectorAll(
+      'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])'
+    )).filter((element) => !element.hidden && element.getClientRects().length > 0);
+
+    const setOpen = (open, options = {}) => {
+      const shouldFocus = options.focus !== false;
+      toggle.setAttribute('aria-expanded', String(open));
+      toggle.setAttribute('aria-label', open ? 'Close navigation menu' : 'Open navigation menu');
+      drawer.classList.toggle('is-open', open);
+      backdrop.classList.toggle('is-open', open);
+      drawer.setAttribute('aria-hidden', String(!open));
+      document.body.classList.toggle('launch-nav-open', open);
+      if ('inert' in drawer) drawer.inert = !open;
+
+      if (open) {
+        lastFocused = document.activeElement;
+        if (shouldFocus) {
+          window.requestAnimationFrame(() => {
+            const items = focusableItems();
+            (items[0] || drawer).focus({ preventScroll: true });
+          });
+        }
+      } else if (shouldFocus && lastFocused instanceof HTMLElement && document.contains(lastFocused)) {
+        lastFocused.focus({ preventScroll: true });
+      }
+    };
+
+    if ('inert' in drawer) drawer.inert = true;
+
+    toggle.addEventListener('click', (event) => {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      setOpen(toggle.getAttribute('aria-expanded') !== 'true');
+    }, true);
+
+    backdrop.addEventListener('click', () => setOpen(false));
+    drawer.addEventListener('click', (event) => {
+      if (event.target.closest('a[href]')) setOpen(false, { focus: false });
+    });
+
+    document.addEventListener('keydown', (event) => {
+      if (toggle.getAttribute('aria-expanded') !== 'true') return;
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        setOpen(false);
+        return;
+      }
+      if (event.key !== 'Tab') return;
+
+      const items = focusableItems();
+      if (!items.length) {
+        event.preventDefault();
+        drawer.focus();
+        return;
+      }
+      const first = items[0];
+      const last = items[items.length - 1];
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    });
+
+    const handleViewportChange = (event) => {
+      if (!event.matches) setOpen(false, { focus: false });
+    };
+    if (typeof mobileQuery.addEventListener === 'function') mobileQuery.addEventListener('change', handleViewportChange);
+    else if (typeof mobileQuery.addListener === 'function') mobileQuery.addListener(handleViewportChange);
+
+    window.addEventListener('pageshow', () => setOpen(false, { focus: false }));
+  };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initializeLaunchNavigation, { once: true });
+  } else {
+    initializeLaunchNavigation();
+  }
+})();

--- a/portfolio/launch-verify.js
+++ b/portfolio/launch-verify.js
@@ -1,0 +1,53 @@
+'use strict';
+
+const fs = require('fs');
+const html = fs.readFileSync('dist/index.html', 'utf8');
+const resume = fs.readFileSync('dist/resume.html', 'utf8');
+const sitemap = fs.readFileSync('dist/sitemap.xml', 'utf8');
+const robots = fs.readFileSync('dist/robots.txt', 'utf8');
+
+function requireMatch(value, pattern, message) {
+  if (!pattern.test(value)) throw new Error(message);
+}
+
+requireMatch(html, /<html\b[^>]*\blang=["']en["']/i, 'Homepage language is missing');
+requireMatch(html, /<title>Ronal Chhetri \| Senior SEO Specialist and Technical SEO Analyst<\/title>/i, 'Homepage title is incorrect');
+requireMatch(html, /<meta\s+name=["']description["'][^>]*>/i, 'Homepage description is missing');
+requireMatch(html, /<link\s+rel=["']canonical["']\s+href=["']https:\/\/ronalchettri\.netlify\.app\/["']>/i, 'Homepage canonical is incorrect');
+requireMatch(html, /id=["']launch-mobile-drawer["']/i, 'Mobile drawer markup is missing');
+requireMatch(html, /class=["'][^"']*launch-mobile-toggle/i, 'Mobile menu button is missing');
+requireMatch(html, /aria-controls=["']launch-mobile-drawer["']/i, 'Mobile menu ARIA control is missing');
+requireMatch(html, /id=["']services["']/i, 'SEO services content is missing');
+requireMatch(html, /src=["']https:\/\/i\.imgur\.com\/5N1j1Ie\.png["']/i, 'Requested hero image is missing');
+requireMatch(resume, /<link\s+rel=["']canonical["']\s+href=["']https:\/\/ronalchettri\.netlify\.app\/resume["']>/i, 'Resume canonical is incorrect');
+requireMatch(sitemap, /<loc>https:\/\/ronalchettri\.netlify\.app\/<\/loc>/, 'Homepage is missing from sitemap');
+requireMatch(sitemap, /<loc>https:\/\/ronalchettri\.netlify\.app\/resume<\/loc>/, 'Resume is missing from sitemap');
+requireMatch(robots, /Sitemap: https:\/\/ronalchettri\.netlify\.app\/sitemap\.xml/, 'Robots sitemap declaration is missing');
+
+const h1Count = (html.match(/<h1\b/gi) || []).length;
+if (h1Count !== 1) throw new Error(`Expected exactly one homepage H1, found ${h1Count}`);
+
+const description = html.match(/<meta\s+name=["']description["']\s+content=["']([^"']*)["']/i);
+if (!description || description[1].length < 120 || description[1].length > 170) {
+  throw new Error('Homepage description length is outside the launch range');
+}
+
+const drawer = html.match(/<nav\b[^>]*id=["']launch-mobile-drawer["'][^>]*>([\s\S]*?)<\/nav>/i);
+if (!drawer || (drawer[1].match(/<a\b/gi) || []).length < 5) {
+  throw new Error('Mobile drawer does not contain the expected navigation links');
+}
+
+const scripts = Array.from(html.matchAll(/<script\b[^>]*type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi));
+if (!scripts.length) throw new Error('Structured data is missing');
+const graph = scripts.map((match) => JSON.parse(match[1])).find((item) => Array.isArray(item['@graph']));
+if (!graph) throw new Error('Structured data graph is missing');
+const types = graph['@graph'].map((item) => item['@type']);
+for (const type of ['WebSite', 'ProfilePage', 'Person']) {
+  if (!types.includes(type)) throw new Error(`Structured data type ${type} is missing`);
+}
+
+if (/<meta\b[^>]*name=["']keywords["']/i.test(html)) {
+  throw new Error('Obsolete keywords meta tag should not be present');
+}
+
+console.log('Launch validation passed: mobile navigation, metadata, schema, sitemap and crawl rules.');


### PR DESCRIPTION
## What changed

- replaces the broken mobile hamburger behavior with a dedicated accessible drawer
- adds explicit `aria-controls` and `aria-expanded` state, Escape handling, focus trapping, backdrop close, link close, viewport reset, and scroll locking
- preserves the desktop navigation and hides obsolete mobile toggles
- adds a visible SEO services section covering technical SEO, keyword/content strategy, and measurement/implementation
- upgrades homepage and resume titles, descriptions, canonicals, robots directives, Open Graph and Twitter metadata
- adds WebSite, ProfilePage, and Person JSON-LD grounded in Ronal's supplied professional profile
- regenerates robots.txt and sitemap.xml with only indexable canonical URLs
- adds clean URL redirects for resume and legacy pages
- adds noindex headers for legacy, confirmation, and error pages
- adds automated launch checks for mobile navigation markup, JavaScript syntax, one H1, metadata, schema, sitemap, robots rules, hero image, and resume canonical

## Why

The website is scheduled to go live today. The existing hamburger behavior is unreliable on mobile, and the launch needs enforceable technical SEO rather than metadata that can silently regress during the compressed static build.

## Validation

- full zero-dependency build dry run passed locally against a representative site bundle
- shell syntax passed
- enhancement, navigation, and verification JavaScript syntax passed
- generated homepage passed mobile navigation, metadata, structured data, sitemap, robots, and canonical assertions
- Netlify deploy preview required before production merge
